### PR TITLE
Adjustment to changes in EMB v0.10 and EMG v0.12

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## Version 0.2.0 (2026-04-16)
+
+* Adjusted to [`EnergyModelsBase` v0.10.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0) and [`EnergyModelsGeography` v0.10.0](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/releases/tag/v0.12.0):
+* Model worked without adjustments.
+* Breaking change still included to maintain the possibility to do bug fixes in version 0.1.x for existing models with `EnergyModelsBase` v0.9.x.
+* Updated CI versions.
+
 ## Version 0.1.1 (2025-12-16)
 
 * Minor updates to `README.md` and the documentation.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsCompliance"
 uuid = "a12c78df-351d-47be-9a81-17a33aab13b1"
 authors = ["Julian Straus <Julian.Straus@sintef.no>"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -17,8 +17,8 @@ EnergyModelsGeography = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 EMGExt = "EnergyModelsGeography"
 
 [compat]
-EnergyModelsBase = "0.9.0"
-EnergyModelsGeography = "0.11.0"
+EnergyModelsBase = "0.10"
+EnergyModelsGeography = "0.12"
 HiGHS = "1.15.0"
 JuMP = "1.24.0"
 Test = "1.10.0"


### PR DESCRIPTION
This PR increases the compatibility for `EnergyModelsBase` due to the version increase to *[v0.10.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0)* and `EnergyModelsGeography`  to *[v0.12.0](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/releases/tag/v0.12.0)*.

> [!IMPORTANT]  
> The changes related to early retirement do not change the behavior in `EnergyModelsCompliance`. However, to keep backwards bug fix possibilities, it is better to still have a major version increase.